### PR TITLE
fix(output): Use resource name attribute instead of string for name ouput

### DIFF
--- a/output.tf
+++ b/output.tf
@@ -4,7 +4,7 @@ output "created" {
 }
 
 output "name" {
-  value       = local.iam_role_name
+  value       = var.create ? aws_iam_role.lacework_iam_role[0].name : local.iam_role_name
   description = "IAM Role name"
 }
 


### PR DESCRIPTION
***Description:***
Using `local.iam_role_name`as value for the output `name` may lead to a race-condition.

Resource/modules depending on the output `name` might get executed directly even though the actually resource `lacework_iam_role` is not created yet.

```bash
│ Error: Error attaching policy arn:aws:iam::aws:policy/SecurityAudit to IAM Role lacework-security-audit-787bd6: NoSuchEntity: The role with name lacework-security-audit-787bd6 cannot be found.
│ 	status code: 404, request id: cd159d1d-ab1c-4b2b-9e8e-66405ccee104
│
│   with module.lacework_aws_config.aws_iam_role_policy_attachment.security_audit_policy_attachment,
│   on .terraform/modules/lacework_aws_config/main.tf line 24, in resource "aws_iam_role_policy_attachment" "security_audit_policy_attachment":
│   24: resource "aws_iam_role_policy_attachment" "security_audit_policy_attachment" {
```

By using `var.create ? aws_iam_role.lacework_iam_role[0].name : local.iam_role_name` as output value correct dependencies are build and the race-condition will be prevented as the name of the iam_role will only be returned if the resource is actually created.

***Additional Info:***
Terraform code that triggers the race-condition can be found below. Also, the `depends_on` option can be used as a workaround (as seen below).

```hcl
provider "aws" {
  region = var.aws_default_region
}

provider "lacework" {}

data "aws_caller_identity" "current" {}

data "aws_s3_bucket" "existing" {
  bucket = var.existing_s3_bucket
}

data "aws_sns_topic" "existing" {
  name = var.existing_sns_topic
}

resource "random_id" "id" {
  byte_length = 3
}

module "lacework_aws_iam" {
  source  = "lacework/iam-role/aws"
  version = "~> 0.2.2"

  iam_role_name = "lacework-security-audit-${random_id.id.hex}"
  tags = {
    "environment" = var.environment_name
    "owner"       = var.owner_name
  }
}

module "lacework_aws_config" {
  source  = "lacework/config/aws"
  version = "~> 0.4.1"

  # depends_on = [
  #   module.lacework_aws_iam
  # ]

  lacework_integration_name  = "aws-config-${data.aws_caller_identity.current.account_id}-${random_id.id.hex}"
  use_existing_iam_role      = true
  iam_role_name              = module.lacework_aws_iam.name
  iam_role_arn               = module.lacework_aws_iam.arn
  iam_role_external_id       = module.lacework_aws_iam.external_id
  lacework_audit_policy_name = "lwaudit-policy-${var.environment_name}${random_id.id.hex}"
  tags = {
    "environment" = var.environment_name
    "owner"       = var.owner_name
  }
}

module "lacework_aws_cloudtrail" {
  source  = "lacework/cloudtrail/aws"
  version = "~> 0.5.0"

  # depends_on = [
  #   module.lacework_aws_iam
  # ]

  lacework_integration_name = "aws-cloudtrail-${data.aws_caller_identity.current.account_id}-${random_id.id.hex}"
  prefix                    = lower("lacework-ct-${var.environment_name}-${random_id.id.hex}")
  use_existing_iam_role     = true
  iam_role_name             = module.lacework_aws_iam.name
  iam_role_arn              = module.lacework_aws_iam.arn
  iam_role_external_id      = module.lacework_aws_iam.external_id
  use_existing_cloudtrail   = true
  bucket_name               = data.aws_s3_bucket.existing.bucket
  bucket_arn                = data.aws_s3_bucket.existing.arn
  use_existing_sns_topic    = true
  sns_topic_name            = data.aws_sns_topic.existing.name
  sns_topic_arn             = data.aws_sns_topic.existing.arn

  tags = {
    "environment" = var.environment_name
    "owner"       = var.owner_name
  }
}
```

