### PR TITLE
chore: update .terraform entry in .gitignore to exclude lock files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Local .terraform directories
-**/.terraform/*
+**/.terraform*
 
 # .tfstate files
 *.tfstate


### PR DESCRIPTION

## Summary

Our release pipeline failed with:
```
scripts/release.sh prepare                                                                                                                                                                                                       
--> terraform-aws-iam-role: preparing new release                                                                                                                                                                                
xxx terraform-aws-iam-role: You have unsaved changes in the main branch. Are you resuming a release?                                                                                                                             
xxx terraform-aws-iam-role: To resume a release you have to start over, to remove all unsaved changes run the command:                                                                                                           
xxx terraform-aws-iam-role:   git reset --hard origin/main                                                                                                                                                                       
make: *** [GNUmakefile:20: release] Error 127    
```

## How did you test this change?

Will trigger another release! 🤞🏽 

## Issue
https://lacework.atlassian.net/browse/ALLY-892
