### PR TITLE
feat: add permissions_boundary variable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -32,8 +32,9 @@ data "aws_iam_policy_document" "lacework_assume_role_policy" {
 }
 
 resource "aws_iam_role" "lacework_iam_role" {
-  count              = var.create ? 1 : 0
-  name               = local.iam_role_name
-  assume_role_policy = data.aws_iam_policy_document.lacework_assume_role_policy[count.index].json
-  tags               = var.tags
+  count                = var.create ? 1 : 0
+  name                 = local.iam_role_name
+  assume_role_policy   = data.aws_iam_policy_document.lacework_assume_role_policy[count.index].json
+  permissions_boundary = var.permission_boundary_arn
+  tags                 = var.tags
 }

--- a/variables.tf
+++ b/variables.tf
@@ -22,6 +22,12 @@ variable "create" {
   description = "Set to false to prevent the module from creating any resources"
 }
 
+variable "permission_boundary_arn" {
+  type        = string
+  default     = null
+  description = "Optional - ARN of the policy that is used to set the permissions boundary for the role."
+}
+
 variable "tags" {
   type        = map(string)
   description = "A map/dictionary of Tags to be assigned to created resources"


### PR DESCRIPTION
Allows to implement a set of boundaries to the role created by Lacework

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-aws-iam-role/blob/main/CONTRIBUTING.md
--->

## Summary

<!--
Adding Permissions Boundary variable to provide the ability to enforce external permissions rights for the Lacework created role. Requires an already existing permissions boundary. Applying without careful consideration can forbid access to Lacework.
-->

## How did you test this change?

<!--
  How exactly did you verify that your PR solves the issue you wanted to solve?
  Include any other relevant information such as how to use the new functionality, screenshots, etc.
-->

## Issue

<!--
  Include the link to a Jira/Github issue
-->
