### PR TITLE
refactor: change version pinning to allow Terrafrom 0.13

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.14"
+  required_version = ">= 0.13"
 
   required_providers {
     aws    = ">= 3.0"


### PR DESCRIPTION
## Summary

Revert deprecation of Terraform version 0.13. 

## Issue
https://lacework.atlassian.net/browse/GROW-1349

https://github.com/lacework/terraform-aws-config/issues/56