### PR TITLE
Remove default aws account number

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Terraform module that creates a cross-account IAM role to integrate Lacework and
 | <a name="input_create"></a> [create](#input\_create) | Set to false to prevent the module from creating any resources | `bool` | `true` | no |
 | <a name="input_external_id_length"></a> [external\_id\_length](#input\_external\_id\_length) | The length of the external ID to generate | `number` | `16` | no |
 | <a name="input_iam_role_name"></a> [iam\_role\_name](#input\_iam\_role\_name) | The IAM role name | `string` | `""` | no |
-| <a name="input_lacework_aws_account_id"></a> [lacework\_aws\_account\_id](#input\_lacework\_aws\_account\_id) | The Lacework AWS account that the IAM role will grant access | `string` | `"434813966438"` | no |
+| <a name="input_lacework_aws_account_id"></a> [lacework\_aws\_account\_id](#input\_lacework\_aws\_account\_id) | The Lacework AWS account that the IAM role will grant access | `string` |  | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map/dictionary of Tags to be assigned to created resources | `map(string)` | `{}` | no |
 
 ## Outputs

--- a/variables.tf
+++ b/variables.tf
@@ -6,7 +6,6 @@ variable "iam_role_name" {
 
 variable "lacework_aws_account_id" {
   type        = string
-  default     = "434813966438"
   description = "The Lacework AWS account that the IAM role will grant access"
 }
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-aws-iam-role/blob/main/CONTRIBUTING.md
--->

## Summary

There's no good reason to have a default AWS account ID for this module. This should always be explicitly set.

## How did you test this change?

I ran `tflint` in the repository root.

## Issue

N/A