### PR TITLE
feat: use external id resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ Terraform module that creates a cross-account IAM role to integrate Lacework and
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_create"></a> [create](#input\_create) | Set to false to prevent the module from creating any resources | `bool` | `true` | no |
-| <a name="input_external_id_length"></a> [external\_id\_length](#input\_external\_id\_length) | The length of the external ID to generate | `number` | `16` | no |
 | <a name="input_iam_role_name"></a> [iam\_role\_name](#input\_iam\_role\_name) | The IAM role name | `string` | `""` | no |
 | <a name="input_lacework_aws_account_id"></a> [lacework\_aws\_account\_id](#input\_lacework\_aws\_account\_id) | The Lacework AWS account that the IAM role will grant access | `string` | `"434813966438"` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map/dictionary of Tags to be assigned to created resources | `map(string)` | `{}` | no |

--- a/examples/custom-iam-role/main.tf
+++ b/examples/custom-iam-role/main.tf
@@ -1,7 +1,10 @@
-provider "aws" {}
+provider "aws" {
+    profile = "testing"
+}
+
+provider "lacework" {}
 
 module "lacework_iam_role" {
   source             = "../../"
   iam_role_name      = "custom-role-name"
-  external_id_length = 256
 }

--- a/examples/custom-iam-role/main.tf
+++ b/examples/custom-iam-role/main.tf
@@ -1,6 +1,4 @@
-provider "aws" {
-    profile = "testing"
-}
+provider "aws" {}
 
 provider "lacework" {}
 

--- a/examples/custom-iam-role/versions.tf
+++ b/examples/custom-iam-role/versions.tf
@@ -1,0 +1,8 @@
+# required for Terraform 13
+terraform {
+  required_providers {
+    lacework = {
+      source = "lacework/lacework"
+    }
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -6,10 +6,10 @@ resource "random_id" "uniq" {
   byte_length = 4
 }
 
-resource "random_string" "external_id" {
-  count            = var.create ? 1 : 0
-  length           = var.external_id_length
-  override_special = "=,.@:/-"
+resource "lacework_external_id" "aws_iam_external_id" {
+  count      = var.create ? 1 : 0
+  csp        = "aws"
+  account_id = var.lacework_aws_account_id
 }
 
 data "aws_iam_policy_document" "lacework_assume_role_policy" {
@@ -26,7 +26,7 @@ data "aws_iam_policy_document" "lacework_assume_role_policy" {
     condition {
       test     = "StringEquals"
       variable = "sts:ExternalId"
-      values   = [random_string.external_id[count.index].result]
+      values   = [lacework_external_id.aws_iam_external_id[count.index].v2]
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -6,10 +6,12 @@ resource "random_id" "uniq" {
   byte_length = 4
 }
 
+data "aws_caller_identity" "current" {}
+
 resource "lacework_external_id" "aws_iam_external_id" {
   count      = var.create ? 1 : 0
   csp        = "aws"
-  account_id = var.lacework_aws_account_id
+  account_id = data.aws_caller_identity.current.account_id
 }
 
 data "aws_iam_policy_document" "lacework_assume_role_policy" {

--- a/output.tf
+++ b/output.tf
@@ -14,6 +14,6 @@ output "arn" {
 }
 
 output "external_id" {
-  value       = var.create ? random_string.external_id[0].result : ""
+  value       = var.create ? lacework_external_id.aws_iam_external_id[0].v2 : ""
   description = "The External ID configured into the IAM role"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -10,6 +10,12 @@ variable "lacework_aws_account_id" {
   description = "The Lacework AWS account that the IAM role will grant access"
 }
 
+variable "external_id_length" {
+  type        = number
+  default     = 16
+  description = "The length of the external ID to generate. **Deprecated** - Will be removed on our next major release v1.0.0"
+}
+
 variable "create" {
   type        = bool
   default     = true

--- a/variables.tf
+++ b/variables.tf
@@ -10,12 +10,6 @@ variable "lacework_aws_account_id" {
   description = "The Lacework AWS account that the IAM role will grant access"
 }
 
-variable "external_id_length" {
-  type        = number
-  default     = 16
-  description = "The length of the external ID to generate"
-}
-
 variable "create" {
   type        = bool
   default     = true

--- a/variables.tf
+++ b/variables.tf
@@ -13,7 +13,7 @@ variable "lacework_aws_account_id" {
 variable "external_id_length" {
   type        = number
   default     = 16
-  description = "The length of the external ID to generate. **Deprecated** - Will be removed on our next major release v1.0.0"
+  description = "**Deprecated** - Will be removed on our next major release v1.0.0"
 }
 
 variable "create" {

--- a/versions.tf
+++ b/versions.tf
@@ -6,7 +6,7 @@ terraform {
     random = ">= 2.1"
     lacework = {
       source  = "lacework/lacework"
-      version = "~> 1.0"
+      version = "~> 1.5"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -4,5 +4,9 @@ terraform {
   required_providers {
     aws    = ">= 3.0"
     random = ">= 2.1"
+    lacework = {
+      source  = "lacework/lacework"
+      version = "~> 1.0"
+    }
   }
 }


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-aws-iam-role/blob/main/CONTRIBUTING.md
--->

## Summary
Use the new `lacework_external_id` when creating an IAM role

## How did you test this change?

Ran terraform and checked that resources are created correctly with required format

## Issue
https://lacework.atlassian.net/browse/GROW-2420
