### PR TITLE
fix: pin lacework provider version ~> 1.15

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -6,7 +6,7 @@ terraform {
     random = ">= 2.1"
     lacework = {
       source  = "lacework/lacework"
-      version = "~> 1.5"
+      version = "~> 1.15"
     }
   }
 }


### PR DESCRIPTION
We needed this version since that is where we introduced the new resource.

https://github.com/lacework/terraform-provider-lacework/releases/tag/v1.15.0

<img src="https://media0.giphy.com/media/yvBAuESRTsETqNFlEl/giphy.gif"/>